### PR TITLE
Added carbon support to package.json, ran tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "url": "https://github.com/agilemd/joi-fhir/issues"
   },
   "engines": {
-    "node": "6.x"
+    "node": "6.x",
+    "node": "8.x"
   },
   "dependencies": {
     "boom": "7.1.1",


### PR DESCRIPTION
Very simple fix -- package would not install on Node 8.x.  Added node 8.x to the engines array in `package.json`, ran `yarn test`, seems to work fine.